### PR TITLE
[FirebaseObject] Error message is never reset #390

### DIFF
--- a/contrib/test/FirebaseArduino_test.cpp
+++ b/contrib/test/FirebaseArduino_test.cpp
@@ -45,15 +45,15 @@ TEST(FirebaseObjectTest, GetInt) {
 
 TEST(FirebaseObjectTest, GetFloat) {
   {
-    FirebaseObject obj("43.0");
-    EXPECT_EQ(43, obj.getFloat());
+    FirebaseObject obj("43.1");
+    EXPECT_FLOAT_EQ(43.1, obj.getFloat());
     EXPECT_TRUE(obj.success());
     EXPECT_FALSE(obj.failed());
     EXPECT_EQ(obj.error(), "");
   }
   {
     FirebaseObject obj("43");
-    EXPECT_EQ(43, obj.getFloat());
+    EXPECT_FLOAT_EQ(43, obj.getFloat());
     EXPECT_TRUE(obj.success());
     EXPECT_FALSE(obj.failed());
     EXPECT_EQ(obj.error(), "");
@@ -111,6 +111,59 @@ TEST(FirebaseObjectTest, GetStringFailure) {
   EXPECT_TRUE(obj.failed());
   EXPECT_EQ(obj.error(), "failed to convert to string");
 }
+
+TEST(FirebaseObjectTest, GetTwice) {
+  {
+    FirebaseObject obj("{\"foo\":\"bar\"}");
+    EXPECT_EQ(obj.getString("hop"), "");
+    EXPECT_FALSE(obj.success());
+    EXPECT_TRUE(obj.failed());
+    EXPECT_EQ(obj.error(), "failed to convert to string");
+
+    EXPECT_EQ(obj.getString("foo"), "bar");
+    EXPECT_TRUE(obj.success());
+    EXPECT_FALSE(obj.failed());
+    EXPECT_EQ(obj.error(), "");
+  }
+  {
+    FirebaseObject obj("{\"foo\": 42}");
+    EXPECT_EQ(obj.getInt("hop"), 0);
+    EXPECT_FALSE(obj.success());
+    EXPECT_TRUE(obj.failed());
+    EXPECT_EQ(obj.error(), "failed to convert to number");
+
+    EXPECT_EQ(obj.getInt("foo"), 42);
+    EXPECT_TRUE(obj.success());
+    EXPECT_FALSE(obj.failed());
+    EXPECT_EQ(obj.error(), "");
+  }
+  {
+    FirebaseObject obj("{\"foo\": true}");
+    EXPECT_EQ(obj.getBool("hop"), 0);
+    EXPECT_FALSE(obj.success());
+    EXPECT_TRUE(obj.failed());
+    EXPECT_EQ(obj.error(), "failed to convert to bool");
+
+    EXPECT_EQ(obj.getBool("foo"), true);
+    EXPECT_TRUE(obj.success());
+    EXPECT_FALSE(obj.failed());
+    EXPECT_EQ(obj.error(), "");
+  }
+  {
+    FirebaseObject obj("{\"foo\": 43.1}");
+    EXPECT_FLOAT_EQ(obj.getFloat("hop"), 0);
+    EXPECT_FALSE(obj.success());
+    EXPECT_TRUE(obj.failed());
+    EXPECT_EQ(obj.error(), "failed to convert to number");
+
+    EXPECT_FLOAT_EQ(obj.getFloat("foo"), 43.1);
+    EXPECT_TRUE(obj.success());
+    EXPECT_FALSE(obj.failed());
+    EXPECT_EQ(obj.error(), "");
+  }
+}
+
+
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/FirebaseObject.cpp
+++ b/src/FirebaseObject.cpp
@@ -32,6 +32,7 @@ bool FirebaseObject::getBool(const String& path) const {
     error_ = "failed to convert to bool";
     return 0;
   }
+  error_ = "";
   return static_cast<bool>(variant);
 }
 
@@ -41,6 +42,7 @@ int FirebaseObject::getInt(const String& path) const {
     error_ = "failed to convert to number";
     return 0;
   }
+  error_ = "";
   return static_cast<int>(variant);
 }
 
@@ -50,6 +52,7 @@ float FirebaseObject::getFloat(const String& path) const {
     error_ = "failed to convert to number";
     return 0;
   }
+  error_ = "";
   return static_cast<float>(variant);
 }
 
@@ -59,6 +62,7 @@ String FirebaseObject::getString(const String& path) const {
     error_ = "failed to convert to string";
     return "";
   }
+  error_ = "";
   return static_cast<const char*>(variant);
 }
 


### PR DESCRIPTION
PR for #390 

* Reset the `_error` property on each getter call
* Added corresponding tests
* Fixed the existing float test (was comparing int, test was failing with a decimal).