### PR TITLE
Separating WiFiClient.

### DIFF
--- a/src/Firebase.cpp
+++ b/src/Firebase.cpp
@@ -33,8 +33,8 @@ std::string makeFirebaseURL(const std::string& path, const std::string& auth) {
 
 }  // namespace
 
-Firebase::Firebase(const std::string& host, const std::string& auth) : host_(host), auth_(auth) {
-  http_.reset(FirebaseHttpClient::create());
+Firebase::Firebase(WiFiClient* client, const std::string& host, const std::string& auth) : host_(host), auth_(auth) {
+  http_.reset(FirebaseHttpClient::create(client));
   http_->setReuseConnection(true);
 }
 

--- a/src/Firebase.h
+++ b/src/Firebase.h
@@ -32,7 +32,7 @@
 // Firebase REST API client.
 class Firebase {
  public:
-  Firebase(const std::string& host, const std::string& auth = "");
+  Firebase(WiFiClient* client, const std::string& host, const std::string& auth = "");
 
   const std::string& auth() const;
 

--- a/src/FirebaseArduino.cpp
+++ b/src/FirebaseArduino.cpp
@@ -19,14 +19,15 @@
 // This is needed to compile std::string on esp8266.
 template class std::basic_string<char>;
 
-void FirebaseArduino::begin(const String& host, const String& auth) {
+void FirebaseArduino::begin(WiFiClient* client, const String& host, const String& auth) {
   host_ = host.c_str();
   auth_ = auth.c_str();
+  client_ = client;
 }
 
 void FirebaseArduino::initStream() {
   if (stream_http_.get() == nullptr) {
-    stream_http_.reset(FirebaseHttpClient::create());
+    stream_http_.reset(FirebaseHttpClient::create(client_));
     stream_http_->setReuseConnection(true);
     stream_.reset(new FirebaseStream(stream_http_));
   }
@@ -34,7 +35,7 @@ void FirebaseArduino::initStream() {
 
 void FirebaseArduino::initRequest() {
   if (req_http_.get() == nullptr) {
-    req_http_.reset(FirebaseHttpClient::create());
+    req_http_.reset(FirebaseHttpClient::create(client_));
     req_http_->setReuseConnection(true);
     req_.reset(new FirebaseRequest(req_http_));
   }
@@ -197,8 +198,9 @@ bool FirebaseArduino::failed() {
   return error_.code() != 0;
 }
 
-const String& FirebaseArduino::error() {
-  return error_.message().c_str();
+void FirebaseArduino::error(std::string* buf) {
+    std::string err = error_.message();
+    *buf = err;
 }
 
 FirebaseArduino Firebase;

--- a/src/FirebaseArduino.h
+++ b/src/FirebaseArduino.h
@@ -37,7 +37,7 @@ class FirebaseArduino {
    * \param host Your firebase db host, usually X.firebaseio.com.
    * \param auth Optional credentials for the db, a secret or token.
    */
-  virtual void begin(const String& host, const String& auth = "");
+  virtual void begin(WiFiClient* client, const String& host, const String& auth = "");
 
   /**
    * Appends the integer value to the node at path.
@@ -221,7 +221,8 @@ class FirebaseArduino {
   /**
    * \return Error message from last command if failed() is true.
    */
-  virtual const String& error();
+  virtual void error(std::string* buf);
+
  private:
   std::string host_;
   std::string auth_;
@@ -230,6 +231,7 @@ class FirebaseArduino {
   std::shared_ptr<FirebaseRequest> req_;
   std::shared_ptr<FirebaseHttpClient> stream_http_;
   std::shared_ptr<FirebaseStream> stream_;
+  WiFiClient* client_;
 
   void initStream();
   void initRequest();

--- a/src/FirebaseCloudMessaging.cpp
+++ b/src/FirebaseCloudMessaging.cpp
@@ -8,9 +8,10 @@ FirebaseCloudMessage FirebaseCloudMessage::SimpleNotification(
   return message;
 }
 
-FirebaseCloudMessaging::FirebaseCloudMessaging(const std::string& server_key) {
+FirebaseCloudMessaging::FirebaseCloudMessaging(WiFiClient* client, const std::string& server_key) {
   auth_header_ = "key=";
   auth_header_ += server_key;
+  client_ = client;
 }
 
 const FirebaseError FirebaseCloudMessaging::SendMessageToUser(
@@ -63,7 +64,7 @@ const FirebaseError FirebaseCloudMessaging::SendMessageToTopic(
 
 const FirebaseError FirebaseCloudMessaging::SendPayload(
     const char* payload) {
-  std::shared_ptr<FirebaseHttpClient> client(FirebaseHttpClient::create());
+  std::shared_ptr<FirebaseHttpClient> client(FirebaseHttpClient::create(client_));
   client->begin("http://fcm.googleapis.com/fcm/send");
   client->addHeader("Authorization", auth_header_.c_str());
   client->addHeader("Content-Type", "application/json");

--- a/src/FirebaseCloudMessaging.h
+++ b/src/FirebaseCloudMessaging.h
@@ -64,7 +64,7 @@ struct FirebaseCloudMessage {
 // Firebase REST API client.
 class FirebaseCloudMessaging {
  public:
-  FirebaseCloudMessaging(const std::string& server_key);
+  FirebaseCloudMessaging(WiFiClient* client, const std::string& server_key);
   const FirebaseError SendMessageToUser(const std::string& registration_id,
                                         const FirebaseCloudMessage& message);
   const FirebaseError SendMessageToUsers(const std::vector<std::string>& registration_ids,
@@ -82,5 +82,6 @@ class FirebaseCloudMessaging {
   const void AddToJson(const FirebaseCloudMessage& message, JsonObject& json) const;
 
   std::string auth_header_;
+  WiFiClient* client_;
 };
 #endif  // firebase_cloud_messaging_h

--- a/src/FirebaseHttpClient.h
+++ b/src/FirebaseHttpClient.h
@@ -5,6 +5,7 @@
 
 #include "Arduino.h"
 #include "Stream.h"
+#include <WiFiClient.h>
 
 struct HttpStatus {
   static const int TEMPORARY_REDIRECT = 307;
@@ -12,7 +13,7 @@ struct HttpStatus {
 
 class FirebaseHttpClient {
  public:
-  static FirebaseHttpClient* create();
+  static FirebaseHttpClient* create(WiFiClient* client);
 
   virtual void setReuseConnection(bool reuse) = 0;
   virtual void begin(const std::string& url) = 0;
@@ -38,8 +39,5 @@ class FirebaseHttpClient {
  protected:
   static const uint16_t kFirebasePort = 443;
 };
-
-static const char kFirebaseFingerprint[] =
-      "B6 F5 80 C8 B1 DA 61 C1 07 9D 80 42 D8 A9 1F AF 9F C8 96 7D"; // 2019-04
 
 #endif  // FIREBASE_HTTP_CLIENT_H

--- a/src/FirebaseHttpClient_Esp8266.cpp
+++ b/src/FirebaseHttpClient_Esp8266.cpp
@@ -36,7 +36,9 @@ protected:
 
 class FirebaseHttpClientEsp8266 : public FirebaseHttpClient {
  public:
-  FirebaseHttpClientEsp8266() {}
+  FirebaseHttpClientEsp8266(WiFiClient* client) {
+    client_ = client;
+  }
 
   void setReuseConnection(bool reuse) override {
     http_.setReuse(reuse);
@@ -44,11 +46,11 @@ class FirebaseHttpClientEsp8266 : public FirebaseHttpClient {
   }
 
   void begin(const std::string& url) override {
-    http_.begin(url.c_str(), kFirebaseFingerprint);
+    http_.begin(*client_, url.c_str());
   }
 
   void begin(const std::string& host, const std::string& path) override {
-    http_.begin(host.c_str(), kFirebasePort, path.c_str(), kFirebaseFingerprint);
+    http_.begin(*client_, host.c_str(), kFirebasePort, path.c_str());
   }
 
   void end() override {
@@ -89,9 +91,10 @@ class FirebaseHttpClientEsp8266 : public FirebaseHttpClient {
 
  private:
   ForceReuseHTTPClient http_;
+  WiFiClient* client_;
 };
 
-FirebaseHttpClient* FirebaseHttpClient::create() {
-  return new FirebaseHttpClientEsp8266();
+FirebaseHttpClient* FirebaseHttpClient::create(WiFiClient* client) {
+  return new FirebaseHttpClientEsp8266(client);
 }
  


### PR DESCRIPTION
We can now pass in a reference to a WiFi client from calling code.
This way, we can set up the client to authenticate with a fingerprint,
a certificate, or use an insecure client. The fingerprint no longer
needs to be compiled with the library, therefore, the library won't
need to be updated whenever the cert changes. This commit also fixes
broken error message retrieval.